### PR TITLE
Enhancements

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,14 @@ import (
 	"syscall"
 )
 
+type ConnectionError struct {
+	error
+}
+
+type CloudInitError struct {
+	error
+}
+
 func PublicKeyFile(file string) ssh.AuthMethod {
 	buffer, err := ioutil.ReadFile(file)
 	if err != nil {
@@ -46,20 +54,20 @@ func Run(conf *Config) error {
 	server := fmt.Sprintf("%s:%d", conf.Hostname, conf.Port)
 	conn, err := ssh.Dial("tcp", server, config)
 	if err != nil {
-		return fmt.Errorf("Unable to dial: %v", err)
+		return &ConnectionError{fmt.Errorf("Unable to dial: %v", err)}
 	}
 
 	if conf.UserData != "" {
-		err = ensureUserData(conn, conf.Stdout, conf.UserData)
+		err = ensureCloudData(conn, conf)
 		if err != nil {
-			return fmt.Errorf("Unable to transfer userdata: %v", err)
+			return &CloudInitError{fmt.Errorf("Unable to transfer userdata: %v", err)}
 		}
 	}
 
-	err = executeCmds(conn, conf.Stdout, conf.GetCmds())
+	err = executeCmds(conn, conf)
 	if err != nil {
 		fmt.Printf("Error: %s", err)
-		return fmt.Errorf("Unable to execute commands: %v", err)
+		return &CloudInitError{fmt.Errorf("Unable to execute commands: %v", err)}
 	}
 	return nil
 }

--- a/client/config.go
+++ b/client/config.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"fmt"
 	"io"
+	"strings"
 )
 
 type Config struct {
@@ -24,12 +26,18 @@ func (conf *Config) GetCmds() []string {
 	if len(conf.Cmds) > 0 {
 		return conf.Cmds
 	}
-	if conf.Os == "ubuntu" {
+	os := strings.ToLower(conf.Os)
+	if os == "ubuntu" {
 		return GetUbuntuCmds(conf)
-	} else if conf.Os == "centos" {
+	} else if os == "centos" {
 		return GetCentOSCmds(conf)
-	} else if conf.Os == "coreos" {
+	} else if os == "coreos" {
 		return GetCoreOSCmds(conf)
+	} else {
+		if conf.Stdout != nil {
+			fmt.Fprintf(conf.Stdout, "Warning: unsupported system for ssh-cloudinit: %s", conf.Os)
+		}
+
 	}
 	return []string{}
 }

--- a/client/config.go
+++ b/client/config.go
@@ -5,17 +5,19 @@ import (
 )
 
 type Config struct {
-	Hostname      string
-	Port          int
-	User          string
-	Password      string
-	PublicKeyFile string
-	Cmds          []string
-	Os            string
-	Server        string
-	UserData      string
-	Callback      string
-	Stdout        io.Writer
+	Hostname                 string
+	Port                     int
+	User                     string
+	Password                 string
+	PublicKeyFile            string
+	Cmds                     []string
+	Os                       string
+	Server                   string
+	DontCleanCloudInitStatus bool
+	UseCloudDataSource       bool
+	UserData                 string
+	Callback                 string
+	Stdout                   io.Writer
 }
 
 func (conf *Config) GetCmds() []string {
@@ -24,8 +26,9 @@ func (conf *Config) GetCmds() []string {
 	}
 	if conf.Os == "ubuntu" {
 		return GetUbuntuCmds(conf)
-	}
-	if conf.Os == "coreos" {
+	} else if conf.Os == "centos" {
+		return GetCentOSCmds(conf)
+	} else if conf.Os == "coreos" {
 		return GetCoreOSCmds(conf)
 	}
 	return []string{}

--- a/client/os.go
+++ b/client/os.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 )
 
-const CloudDataPath = "/tmp/cloud/"
+const CloudDataPath = "/opt/cloud/"
 
 func GetCentOSCmds(conf *Config) []string {
 	s := conf.Server
-	extra := ""
+	flags := ""
+	source := ""
 	if conf.UserData != "" {
 		s = CloudDataPath
 	} else if !strings.HasSuffix(s, "/") {
@@ -19,39 +20,53 @@ func GetCentOSCmds(conf *Config) []string {
 	cmds := []string{
 		"sudo yum update",
 		"sudo yum -y install cloud-init curl wget",
-		fmt.Sprintf("sudo cloud-init %s init -l", extra),
-		fmt.Sprintf("sudo cloud-init %s modules -m config", extra),
-		fmt.Sprintf("sudo cloud-init %s modules -m final", extra),
 	}
+
 	if conf.UseCloudDataSource == false {
-		//cmds = append([]string{fmt.Sprintf("sudo echo 'apt_preserve_sources_list: true\ncloud_init_modules: [write-files, update_etc_hosts, users-groups]\ncloud_final_modules: [scripts-vendor, scripts-per-once, scripts-per-boot, scripts-per-instance, scripts-user]\nusers: []\ndatasource_list: [NoCloud]\ndatasource: \n  NoCloud: \n    seedfrom: %s' > /etc/cloud/cloud.cfg.d/95_nocloud.cfg", s)}, cmds...)
+		flags = "-l"
+		cmds = append(cmds, fmt.Sprintf("sudo echo 'apt_preserve_sources_list: true\ncloud_init_modules: [write-files, update_etc_hosts, users-groups]\ncloud_final_modules: [scripts-vendor, scripts-per-once, scripts-per-boot, scripts-per-instance, scripts-user]\nusers: []\ndatasource_list: [NoCloud]\ndatasource: \n  NoCloud: \n    seedfrom: %s' > /etc/cloud/cloud.cfg.d/95_nocloud.cfg", s))
+	} else {
+		source = fmt.Sprintf("-f %s", path.Join(CloudDataPath, "user-data"))
 	}
+
+	cmds = append(cmds,
+		fmt.Sprintf("sudo cloud-init %s init %s", source, flags),
+		fmt.Sprintf("sudo cloud-init %s modules -m config", source),
+		fmt.Sprintf("sudo cloud-init %s modules -m final", source),
+	)
+
 	if conf.DontCleanCloudInitStatus == false {
 		cmds = append([]string{"sudo rm -rf /var/lib/cloud/instance/*"}, cmds...)
 	}
+
 	return cmds
 }
 func GetUbuntuCmds(conf *Config) []string {
 	s := conf.Server
-	extra := ""
+	flags := ""
+	source := ""
 	if conf.UserData != "" {
 		s = CloudDataPath
 	} else if !strings.HasSuffix(s, "/") {
 		s = s + "/"
 	}
 	cmds := []string{
-		"sudo apt-get update",
-		"sudo apt-get -y install cloud-init curl wget",
+		"sudo apt-get update -q",
+		"sudo sh -c 'which cloud-init || apt-get -y -q install cloud-init'",
+		"sudo apt-get -y -q install curl wget",
 	}
 
 	if conf.UseCloudDataSource == false {
+		flags = "-l"
 		cmds = append(cmds, fmt.Sprintf("sudo sh -c \"echo 'apt_preserve_sources_list: true\ncloud_init_modules: [write-files, update_etc_hosts, users-groups]\ncloud_final_modules: [scripts-vendor, scripts-per-once, scripts-per-boot, scripts-per-instance, scripts-user]\nusers: []\ndatasource_list: [NoCloud]\ndatasource: \n  NoCloud: \n    seedfrom: %s' > /etc/cloud/cloud.cfg.d/96_nocloud.cfg\"", s))
+	} else {
+		source = fmt.Sprintf("-f %s", path.Join(CloudDataPath, "user-data"))
 	}
 
 	cmds = append(cmds,
-		fmt.Sprintf("sudo cloud-init %s init -l", extra),
-		fmt.Sprintf("sudo cloud-init %s modules -m config", extra),
-		fmt.Sprintf("sudo cloud-init %s modules -m final", extra),
+		fmt.Sprintf("sudo cloud-init %s init %s", source, flags),
+		fmt.Sprintf("sudo cloud-init %s modules -m config", source),
+		fmt.Sprintf("sudo cloud-init %s modules -m final", source),
 	)
 
 	if conf.DontCleanCloudInitStatus == false {

--- a/client/os.go
+++ b/client/os.go
@@ -2,31 +2,69 @@ package client
 
 import (
 	"fmt"
+	"path"
 	"strings"
 )
 
-const UserDataPath = "/tmp/userdata"
+const CloudDataPath = "/tmp/cloud/"
 
-func GetUbuntuCmds(conf *Config) []string {
+func GetCentOSCmds(conf *Config) []string {
 	s := conf.Server
-	if !strings.HasSuffix(s, "/") {
+	extra := ""
+	if conf.UserData != "" {
+		s = CloudDataPath
+	} else if !strings.HasSuffix(s, "/") {
 		s = s + "/"
 	}
-	return []string{
+	cmds := []string{
+		"sudo yum update",
+		"sudo yum -y install cloud-init curl wget",
+		fmt.Sprintf("sudo cloud-init %s init -l", extra),
+		fmt.Sprintf("sudo cloud-init %s modules -m config", extra),
+		fmt.Sprintf("sudo cloud-init %s modules -m final", extra),
+	}
+	if conf.UseCloudDataSource == false {
+		//cmds = append([]string{fmt.Sprintf("sudo echo 'apt_preserve_sources_list: true\ncloud_init_modules: [write-files, update_etc_hosts, users-groups]\ncloud_final_modules: [scripts-vendor, scripts-per-once, scripts-per-boot, scripts-per-instance, scripts-user]\nusers: []\ndatasource_list: [NoCloud]\ndatasource: \n  NoCloud: \n    seedfrom: %s' > /etc/cloud/cloud.cfg.d/95_nocloud.cfg", s)}, cmds...)
+	}
+	if conf.DontCleanCloudInitStatus == false {
+		cmds = append([]string{"sudo rm -rf /var/lib/cloud/instance/*"}, cmds...)
+	}
+	return cmds
+}
+func GetUbuntuCmds(conf *Config) []string {
+	s := conf.Server
+	extra := ""
+	if conf.UserData != "" {
+		s = CloudDataPath
+	} else if !strings.HasSuffix(s, "/") {
+		s = s + "/"
+	}
+	cmds := []string{
 		"sudo apt-get update",
 		"sudo apt-get -y install cloud-init curl wget",
-		fmt.Sprintf("sudo echo 'apt_preserve_sources_list: true\ncloud_init_modules: [write-files, update_etc_hosts, users-groups]\ncloud_final_modules: [scripts-vendor, scripts-per-once, scripts-per-boot, scripts-per-instance, scripts-user]\nusers: []\ndatasource_list: [NoCloud]\ndatasource: \n  NoCloud: \n    seedfrom: %s' > /etc/cloud/cloud.cfg.d/95_nocloud.cfg", s),
-		"sudo rm -rf /var/lib/cloud/instance/*",
-		"sudo cloud-init init",
-		"sudo cloud-init modules -m config",
-		"sudo cloud-init modules -m final",
 	}
+
+	if conf.UseCloudDataSource == false {
+		cmds = append(cmds, fmt.Sprintf("sudo sh -c \"echo 'apt_preserve_sources_list: true\ncloud_init_modules: [write-files, update_etc_hosts, users-groups]\ncloud_final_modules: [scripts-vendor, scripts-per-once, scripts-per-boot, scripts-per-instance, scripts-user]\nusers: []\ndatasource_list: [NoCloud]\ndatasource: \n  NoCloud: \n    seedfrom: %s' > /etc/cloud/cloud.cfg.d/96_nocloud.cfg\"", s))
+	}
+
+	cmds = append(cmds,
+		fmt.Sprintf("sudo cloud-init %s init -l", extra),
+		fmt.Sprintf("sudo cloud-init %s modules -m config", extra),
+		fmt.Sprintf("sudo cloud-init %s modules -m final", extra),
+	)
+
+	if conf.DontCleanCloudInitStatus == false {
+		cmds = append([]string{"sudo rm -rf /var/lib/cloud/instance/*"}, cmds...)
+	}
+	return cmds
 }
 
 func GetCoreOSCmds(conf *Config) []string {
+	filePath := path.Join(CloudDataPath, "user-data")
 	if conf.UserData != "" {
 		return []string{
-			fmt.Sprintf("sudo coreos-cloudinit --from-file=%s", UserDataPath),
+			fmt.Sprintf("sudo coreos-cloudinit --from-file=%s", filePath),
 		}
 	}
 

--- a/client/ssh.go
+++ b/client/ssh.go
@@ -97,6 +97,7 @@ func executeCmds(conn *ssh.Client, conf *Config) (err error) {
 			ignoreError = true
 			command = command[2:]
 		}
+		fmt.Printf(">>> %s\n", command)
 		fmt.Fprintf(session.Stdout, ">>> %s\n", command)
 
 		err = session.Run(command)

--- a/client/ssh.go
+++ b/client/ssh.go
@@ -4,50 +4,139 @@ import (
 	"fmt"
 	"golang.org/x/crypto/ssh"
 	"io"
-	"path/filepath"
+	"path"
+	"strings"
 )
 
-func ensureUserData(conn *ssh.Client, stdout io.Writer, data string) error {
+func runCmd(conn *ssh.Client, conf *Config, cmd string) error {
+	session, err := newSession(conn, conf)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	return session.Run(cmd)
+}
+
+func ensureCloudData(conn *ssh.Client, conf *Config) error {
+	err := runCmd(conn, conf, fmt.Sprintf("sudo sh -c 'rm -rf %s; mkdir -p %s && chown %s %s'", CloudDataPath, CloudDataPath, conf.User, CloudDataPath))
+	if err != nil {
+		return err
+	}
+
+	err = runCmd(conn, conf, fmt.Sprintf("echo 'dsmode: local' > %s", path.Join(CloudDataPath, "meta-data")))
+	if err != nil {
+		return err
+	}
+
 	session, err := conn.NewSession()
 	if err != nil {
 		return err
 	}
 	defer session.Close()
 
-	dir := filepath.Dir(UserDataPath)
-	filename := filepath.Base(UserDataPath)
-	session.Stdout = stdout
+	session.Stdout = conf.Stdout
+	fmt.Fprint(conf.Stdout, "> Uploading data\n")
 
 	go func() {
 		w, _ := session.StdinPipe()
 		defer w.Close()
 
-		fmt.Fprintln(w, "C0644", len(data), filename)
-		fmt.Fprint(w, data)
+		fmt.Fprintln(w, "C0644", len(conf.UserData), "user-data")
+		fmt.Fprint(w, conf.UserData)
 		fmt.Fprint(w, "\x00")
 	}()
 
-	err = session.Run(fmt.Sprintf("/usr/bin/scp -t %s", dir))
-	if err != nil {
-		return err
-	}
-	return nil
+	err = session.Run(fmt.Sprintf("scp -t %s", CloudDataPath))
+	return err
 }
 
-func executeCmds(conn *ssh.Client, stdout io.Writer, commands []string) (err error) {
+func newSession(conn *ssh.Client, conf *Config) (session *ssh.Session, err error) {
+	session, err = conn.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	modes := ssh.TerminalModes{
+		ssh.ECHO:          0,     // disable echoing
+		ssh.TTY_OP_ISPEED: 14400, // input speed = 14.4kbaud
+		ssh.TTY_OP_OSPEED: 14400, // output speed = 14.4kbaud
+	}
+
+	err = session.RequestPty("xterm", 80, 25, modes)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to request pty: %v", err)
+	}
+
+	stdinPipe, err := session.StdinPipe()
+	if err != nil {
+		return
+	}
+
+	stdout := &SudoPipe{
+		Stdout:    conf.Stdout,
+		StdinPipe: stdinPipe,
+		Password:  conf.Password,
+	}
+	session.Stdout = stdout
+
+	return session, nil
+}
+
+func executeCmds(conn *ssh.Client, conf *Config) (err error) {
+	commands := conf.GetCmds()
 	for _, command := range commands {
-		session, err := conn.NewSession()
+		session, err := newSession(conn, conf)
 		if err != nil {
 			return err
 		}
 		defer session.Close()
 
-		session.Stdout = stdout
+		ignoreError := false
+		if strings.HasPrefix(command, "! ") {
+			ignoreError = true
+			command = command[2:]
+		}
+		fmt.Fprintf(session.Stdout, ">>> %s\n", command)
 
-		fmt.Fprintf(stdout, ">>> %s\n", command)
 		err = session.Run(command)
-		if err != nil {
+		if err != nil && !ignoreError {
 			return err
+		}
+	}
+
+	return
+}
+
+type SudoPipe struct {
+	Stdout    io.Writer
+	StdinPipe io.Writer
+	Password  string
+
+	line []byte
+}
+
+func (sp *SudoPipe) Write(p []byte) (count int, err error) {
+	if sp.Stdout != nil {
+		count, err = sp.Stdout.Write(p)
+	}
+
+	if sp.Password == "" || sp.StdinPipe == nil {
+		return
+	}
+
+	for _, b := range p {
+		sp.line = append(sp.line, b)
+		line := string(sp.line)
+		if strings.HasPrefix(line, "[sudo] password for ") && strings.HasSuffix(line, ": ") {
+			_, err = sp.StdinPipe.Write([]byte(sp.Password + "\n"))
+			if err != nil {
+				break
+			}
+		}
+
+		if b == '\n' {
+			sp.line = []byte{}
 		}
 	}
 


### PR DESCRIPTION
Work on different kinds of providers:

* For providers with cloudinit support, we use metadata from the meta server, and our own uploaded userdata. (achieved with cloud-init -f)
* For providers without cloudinit support, we install cloud-init package, create a folder structure on /opt/cloud with meta-data and user-data, make NoCloud datasource to use that, and run cloud-init in local mode.

Returned error types are also enhanced so connection errors and real cloud-init errors can be processed respectively. 

Non-root users are supported.